### PR TITLE
Fixed the path for PID_DIR, when the WORKDIR is home

### DIFF
--- a/pmonitor/pmon
+++ b/pmonitor/pmon
@@ -21,7 +21,7 @@ while [ "$1" != "" ]; do
   shift;
 done;
 
-export PID_DIR=${WORKDIR}/pid_monitor
+export PID_DIR=${WORKDIR}/perftools-setup/pid_monitor
 
 export WORKLOAD_NAME=${workname}
 export DESCRIPTION=${workname}


### PR DESCRIPTION
I was getting errors that setup-run.sh was not found
/home/hdp_test//perftools-setup/pmonitor/pmon: line 34: /home/hdp_test/pid_monitor/setup-run.sh: No such file or directory
SLAVES : localhost localhost
/home/hdp_test//perftools-setup/pmonitor/pmon: line 64: ./run-workload.sh: No such file or directory
